### PR TITLE
Fixed make errors on a Ubuntu VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ clean:
 # public dir cleanup.
 .PHONY: clean-public
 clean-public:
-	bash -O extglob -c 'rm -rf public/!(.git|version)'
+	bash -O extglob -c 'rm -rf public/!(.git|version|.|..)'
 
 # versioned archives cleanup.
 .PHONY: clean-archives


### PR DESCRIPTION
Excluded . and .. to prevent rm from saying
rm: cannot remove directory: ‘public/.’
rm: cannot remove directory: ‘public/..’

It's a small fix that probably won't affect many people other than me, but it gets things working for me nonetheless.
