### PR TITLE
Added period after the word 'formation'

### DIFF
--- a/src/interactives/interactions/forming-molecules-graph.json
+++ b/src/interactives/interactions/forming-molecules-graph.json
@@ -1,5 +1,5 @@
 {
-  "title": "Energy of Bond Formation",
+  "title": "Energy of Bond Formation.",
   "publicationStatus": "draft",
   "subtitle": "",
   "about": "",

--- a/src/models/lab-version/1/md2d/interactions/forming-molecule.json
+++ b/src/models/lab-version/1/md2d/interactions/forming-molecule.json
@@ -87,7 +87,7 @@
         "fontSize": 0.5
       },
       {
-        "text": "Drag an atom's nucleus to explore bond formation",
+        "text": "Drag an atom's nucleus to explore bond formation.",
         "x": 1,
         "y": 3,
         "layer": 1,


### PR DESCRIPTION
Though it isn't anything really. But I saw this issue lying un-attended in pivotal-tracker. :P