### PR TITLE
Add Docker support for containerizing web application.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.bundle/
+.sass-cache/
+public/
+node_modules/
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:trusty
+
+WORKDIR /srv
+RUN apt-get update && apt-get upgrade -y && apt-get clean
+
+# Install RVM
+RUN apt-get install -y curl && apt-get clean
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN curl -sSL https://get.rvm.io | bash -s stable && apt-get clean
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm; rvm install ruby-2.0.0-p247"
+RUN echo "source /usr/local/rvm/scripts/rvm" >> /root/.bashrc
+
+# Install Node.js
+RUN apt-get install -y software-properties-common && apt-get clean
+RUN apt-add-repository -y ppa:chris-lea/node.js
+RUN apt-get install -y nodejs npm && apt-get clean
+RUN ln -sf /usr/bin/nodejs /usr/bin/node
+
+# Setup app
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+RUN apt-get install -y git libxslt-dev libxml2-dev python-pip && apt-get clean
+RUN pip install supervisor
+COPY . /srv/
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm; gem install bundle"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm; bundle install"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm; gem install rb-readline"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm; make everything"
+
+EXPOSE 9292 35729
+CMD ["/bin/bash", "-c", "source /usr/local/rvm/scripts/rvm; /usr/local/bin/supervisord -c /srv/config/supervisord.conf -j /tmp/supervisord.pid"]

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -1,0 +1,26 @@
+########################################
+# This is used inside Docker container #
+########################################
+
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+
+[program:rackup]
+command=rackup
+autorestart=false
+redirect_stdout=true
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:guard]
+command=guard
+redirect_stdout=true
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/developer-doc/docker.md
+++ b/developer-doc/docker.md
@@ -1,0 +1,40 @@
+# Docker Container
+
+## Introduction
+
+[Docker](https://www.docker.com/) is an open platform for distributed applications for developers and sysadmins. It can be used to quickly develop and deploy web applications.
+
+You will need to first install Docker. Instructions can be found here:
+
+ - [Linux](https://docs.docker.com/linux/started/)
+ - [Mac](https://docs.docker.com/mac/started/)
+ - [Windows](https://docs.docker.com/windows/started/)
+
+## Build and Run a Container
+
+To build and run a container:
+
+1. `docker build -t lab-interactives-site .`
+2. `docker run --name interactives -p 9292:9292 -p 35729:35729 lab-interactives-site`
+
+If you have `docker-compose` installed, this process is even easier:
+
+1. `docker-compose build`
+2. `docker-compose up`
+
+Once the container is running, you can open a second terminal and run:
+
+    docker exec -ti <container_name> /bin/bash
+
+This will allow you to run other commands like `make all`.
+
+## Extra Notes For `docker-machine`/`boot2docker`
+
+To connect to the [LiveReload](http://livereload.com/extensions/#installing-sections) server, you'll have to create an SSH tunnel after the container has started.
+
+1. Run `docker-machine env default` to get the machine's IP address
+2. Run `ssh -N -L 35729:localhost:35729 docker@<ip_addr_for_docker_machine>` to start the ssh tunnel
+
+If you don't want to bother with SSH tunnels, you can use [RemoteLiveReload](https://github.com/bigwave/livereload-extensions) instead. However, you'll have to run the following command before building and starting the container.
+
+    sed -i "s/guard 'livereload'/guard 'livereload', host: '0.0.0.0', port: '35729'/" Guardfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+web:
+    build: .
+    volumes:
+        - .:/srv
+    ports:
+        - "9292:9292"    # web server
+        - "35729:35729"  # LiveReload server

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,10 @@ third-parties and are distributed under either BSD, MIT, or Apache 2.0 licenses.
 It is recommended that you review the [initial setup details](developer-doc/initial-setup-details.md).
 They describe what each of the steps above does.
 
+## Run Docker Container
+
+See the [Docker documentation](developer-doc/docker.md) for more information.
+
 ## Contributing to Lab Interactives Site
 
 If you think you'd like to contribute to Lab Interactives Site as an external developer:


### PR DESCRIPTION
This adds support for creating a sandboxed environment specifically for lab-interactives-site. This will allow people to skip the environment setup and go straight into developing/extending the web application.