### PR TITLE
Suport building standalone version of jsmol interactives

### DIFF
--- a/src/standalone/create.html
+++ b/src/standalone/create.html
@@ -9,12 +9,17 @@
   	<h2>Standalone Interactive Creation Tool</h2>
   	This page is only intended to work on Google Chrome. It might work on other browsers but they are not supported.
     <ol>
-  		<li>Download the resources needed for all interactives: <a href="lab-interactive.tar.gz">lab-interactive.tar.gz</a>
-  		</li>
-  		<li>Unzip the file above which should give you a folder 'lab-interactive'</li>
-  		<li>Put the path to the interactive after the '#' in the URL above</li>
+  		<li>Download the resources needed for all interactives: <a href="lab-interactive.tar.gz">lab-interactive.tar.gz</a>.</li>
+  		<li>Unzip the file above which should give you a folder 'lab-interactive'.</li>
+			<li>JSmol interactives <b>only</b>:
+				<ol>
+					<li>Download JSmol offline bundle: <a href="https://models-resources.concord.org/jsmol/jsmol-offline.tar.gz">jsmol-offline.tar.gz</a>.</li>
+					<li>Unzip it, and move it inside the 'lab-interactive' folder created above.</li>
+				</ol>
+			</li>
+  		<li>Put the path to the interactive after the '#' in the URL above.</li>
   		<li>Click the Download HTML link below, and move the downloaded file inside the 'lab-interactive' folder created
-  			above</li>
+  			above.</li>
   		<li>Open this new file in a browser, you should see a file:// URL and the interactive should load.</li>
   		<li>Disconnect your network, clear your browser cache and try loading the file again to make sure
   			it has everything it needs.</li>
@@ -73,25 +78,22 @@
           	});
 
           	$.when.apply($,promises).then(function() {
-	          var interactive_def,
-	      	      inlined,
-	      	      blob, blob_url;
-	      	  interactive_def = "window.INTERACTIVE=" +
-	      	    JSON.stringify(interactive, null, 2) +
-	      	    ";"
-	      	  inlined = template_html.replace("// SPOT_TO_PUT_INLINE_INTERACTIVE_AND_MODEL",
-	      	  	"window.INTERACTIVE=" + JSON.stringify(interactive, null, 2) + ";");
+						var interactiveDef = JSON.stringify(interactive, null, 2);
+						// Replace jsmol embeddable page with local, offline bundle (needs to be downloaded by user).
+						interactiveDef = interactiveDef.replace('https://models-resources.concord.org/jsmol', 'jsmol-offline');
+	      	  var inlined = template_html.replace("// SPOT_TO_PUT_INLINE_INTERACTIVE_AND_MODEL",
+	      	  	"window.INTERACTIVE=" + interactiveDef + ";");
 	      	  // The following injection is so the sharing URL points back to the current
 	      	  // interactive site. The homEmbeddablePath is being abused a little bit here.
-	      	  // it is intented to just point at embeddable.html, and then the hash of the page
+	      	  // it is intended to just point at embeddable.html, and then the hash of the page
 	      	  // is appended to it by lab.js. But in the standalone case there is no
 	      	  // hash. So in this case we are setting homeEmbeddablePath to something like
 	      	  // /embeddable.html#interactives/samples/1-oil-and-water.json
 	      	  inlined = inlined.replace("// SPOT_TO_INJECT_CUSTOMIZED_CONFIGURATION",
 	      	  	'Lab.config.homeForSharing="' + getHomeForSharing() + '";\n' +
 	      	  	'Lab.config.homeEmbeddablePath="/embeddable.html' + window.location.hash + '";');
-	      	  blob = new Blob([inlined], {type : 'text/html'})
-	      	  blob_url = URL.createObjectURL(blob);
+	      	  var blob = new Blob([inlined], {type : 'text/html'});
+	      	  var blob_url = URL.createObjectURL(blob);
 	      	  $('#download_link_container').append('<a href="' + blob_url + '" download="' + interactive.title + '.html">Download HTML</a>');
 	      	  $('#standalone_html').val(inlined);
             });

--- a/src/standalone/create.html
+++ b/src/standalone/create.html
@@ -1,121 +1,125 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
-    <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
-    <script src="../vendor/jquery/jquery.min.js" type="text/javascript"></script>
-  </head>
-  <body>
-  	<h2>Standalone Interactive Creation Tool</h2>
-  	This page is only intended to work on Google Chrome. It might work on other browsers but they are not supported.
+<head>
+  <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+  <meta content='IE=edge,chrome=1' http-equiv='X-UA-Compatible'>
+  <script src="../vendor/jquery/jquery.min.js" type="text/javascript"></script>
+</head>
+<body>
+<h2>Standalone Interactive Creation Tool</h2>
+This page is only intended to work on Google Chrome. It might work on other browsers but they are not supported.
+<ol>
+  <li>Download the resources needed for all interactives: <a href="lab-interactive.tar.gz">lab-interactive.tar.gz</a>.
+  </li>
+  <li>Unzip the file above which should give you a folder 'lab-interactive'.</li>
+  <li>JSmol interactives <b>only</b>:
     <ol>
-  		<li>Download the resources needed for all interactives: <a href="lab-interactive.tar.gz">lab-interactive.tar.gz</a>.</li>
-  		<li>Unzip the file above which should give you a folder 'lab-interactive'.</li>
-			<li>JSmol interactives <b>only</b>:
-				<ol>
-					<li>Download JSmol offline bundle: <a href="https://models-resources.concord.org/jsmol/jsmol-offline.tar.gz">jsmol-offline.tar.gz</a>.</li>
-					<li>Unzip it, and move it inside the 'lab-interactive' folder created above.</li>
-				</ol>
-			</li>
-  		<li>Put the path to the interactive after the '#' in the URL above.</li>
-  		<li>Click the Download HTML link below, and move the downloaded file inside the 'lab-interactive' folder created
-  			above.</li>
-  		<li>Open this new file in a browser, you should see a file:// URL and the interactive should load.</li>
-  		<li>Disconnect your network, clear your browser cache and try loading the file again to make sure
-  			it has everything it needs.</li>
-  	</ol>
-  	<p>
-  		NOTE: If the interactive or model has resources it references (like images) you will need to track those down and
-  		put them in the appropriate place.
-    </p>
-    <div id="download_link_container"></div>
-    <h3>Text of the stand alone HTML page</h3>
-  	<textarea id="standalone_html" rows="10" cols="120">
+      <li>Download JSmol offline bundle: <a href="https://models-resources.concord.org/jsmol/jsmol-offline.tar.gz">jsmol-offline.tar.gz</a>.
+      </li>
+      <li>Unzip it, and move it inside the 'lab-interactive' folder created above.</li>
+    </ol>
+  </li>
+  <li>Put the path to the interactive after the '#' in the URL above.</li>
+  <li>Click the Download HTML link below, and move the downloaded file inside the 'lab-interactive' folder created
+    above.
+  </li>
+  <li>Open this new file in a browser, you should see a file:// URL and the interactive should load.</li>
+  <li>Disconnect your network, clear your browser cache and try loading the file again to make sure
+    it has everything it needs.
+  </li>
+</ol>
+<p>
+  NOTE: If the interactive or model has resources it references (like images) you will need to track those down and
+  put them in the appropriate place.
+</p>
+<div id="download_link_container"></div>
+<h3>Text of the stand alone HTML page</h3>
+<textarea id="standalone_html" rows="10" cols="120">
   		Loading Interactive...
   	</textarea>
-  	<script>
-  	  (function (){
-        var template_html,
-            interactive,
-            promises = [],
-            hash = window.location.hash;
+<script>
+  (function () {
+    var template_html,
+      interactive,
+      promises = [],
+      hash = window.location.hash;
 
-        $(window).bind('hashchange', function() {
-          if (document.location.hash !== hash) {
-            location.reload();
-          }
-        });
+    $(window).bind('hashchange', function () {
+      if (document.location.hash !== hash) {
+        location.reload();
+      }
+    });
 
-        // download standalone-template/template.html
-        // download the interactive specified in the hash
-        // download the model files and replace their references in the interactive
-        // inject the interactive into the template
-        // serialize the whole thing into the textarea
-        function getHomeForSharing() {
-            var protocol = window.location.protocol;
-            var host     = window.location.host;
-            var pathname = window.location.pathname;
-            return protocol + "//" + host + pathname.replace("/standalone/create.html", "");
+    // download standalone-template/template.html
+    // download the interactive specified in the hash
+    // download the model files and replace their references in the interactive
+    // inject the interactive into the template
+    // serialize the whole thing into the textarea
+    function getHomeForSharing() {
+      var protocol = window.location.protocol;
+      var host = window.location.host;
+      var pathname = window.location.pathname;
+      return protocol + "//" + host + pathname.replace("/standalone/create.html", "");
+    }
+
+    promises.push($.get("template.html", function (results) {
+      template_html = results;
+    }));
+    $.getJSON("../" + window.location.hash.substring(1)).done(function (results) {
+      interactive = results;
+      // Remove reference to i18nMetadata, as we don't have to support language switching.
+      delete interactive.i18nMetadata;
+      console.log("found " + interactive.models.length + " models");
+      $.each(interactive.models, function (index, model) {
+        if (model.url) {
+          console.log("downloading model: " + model.url);
+          var modelPromise = $.getJSON("../" + model.url).done(function (results) {
+            delete model.url;
+            model.model = results;
+          });
+          promises.push(modelPromise);
         }
+      });
 
-        promises.push($.get("template.html", function(results){
-          	  template_html = results;
-        }));
-        $.getJSON("../" + window.location.hash.substring(1)).done(function(results){
-          	interactive = results;
-            // Remove reference to i18nMetadata, as we don't have to support language switching.
-            delete interactive.i18nMetadata;
-          	console.log("found " + interactive.models.length + " models");
-          	$.each(interactive.models, function(index, model){
-          		if(model.url){
-            		console.log("downloading model: " + model.url);
-          			var modelPromise = $.getJSON("../" + model.url).done(function(results){
-          				delete model.url;
-          				model.model = results;
-          			});
-          			promises.push(modelPromise);
-          		}
-          	});
+      $.when.apply($, promises).then(function () {
+        var interactiveDef = JSON.stringify(interactive, null, 2);
+        // Replace jsmol embeddable page with local, offline bundle (needs to be downloaded by user).
+        interactiveDef = interactiveDef.replace('https://models-resources.concord.org/jsmol', 'jsmol-offline');
+        var inlined = template_html.replace("// SPOT_TO_PUT_INLINE_INTERACTIVE_AND_MODEL",
+          "window.INTERACTIVE=" + interactiveDef + ";");
+        // The following injection is so the sharing URL points back to the current
+        // interactive site. The homEmbeddablePath is being abused a little bit here.
+        // it is intended to just point at embeddable.html, and then the hash of the page
+        // is appended to it by lab.js. But in the standalone case there is no
+        // hash. So in this case we are setting homeEmbeddablePath to something like
+        // /embeddable.html#interactives/samples/1-oil-and-water.json
+        inlined = inlined.replace("// SPOT_TO_INJECT_CUSTOMIZED_CONFIGURATION",
+          'Lab.config.homeForSharing="' + getHomeForSharing() + '";\n' +
+          'Lab.config.homeEmbeddablePath="/embeddable.html' + window.location.hash + '";');
+        var blob = new Blob([inlined], {type: 'text/html'});
+        var blob_url = URL.createObjectURL(blob);
+        $('#download_link_container').append('<a href="' + blob_url + '" download="' + interactive.title + '.html">Download HTML</a>');
+        $('#standalone_html').val(inlined);
+      });
+    });
+  })();
 
-          	$.when.apply($,promises).then(function() {
-						var interactiveDef = JSON.stringify(interactive, null, 2);
-						// Replace jsmol embeddable page with local, offline bundle (needs to be downloaded by user).
-						interactiveDef = interactiveDef.replace('https://models-resources.concord.org/jsmol', 'jsmol-offline');
-	      	  var inlined = template_html.replace("// SPOT_TO_PUT_INLINE_INTERACTIVE_AND_MODEL",
-	      	  	"window.INTERACTIVE=" + interactiveDef + ";");
-	      	  // The following injection is so the sharing URL points back to the current
-	      	  // interactive site. The homEmbeddablePath is being abused a little bit here.
-	      	  // it is intended to just point at embeddable.html, and then the hash of the page
-	      	  // is appended to it by lab.js. But in the standalone case there is no
-	      	  // hash. So in this case we are setting homeEmbeddablePath to something like
-	      	  // /embeddable.html#interactives/samples/1-oil-and-water.json
-	      	  inlined = inlined.replace("// SPOT_TO_INJECT_CUSTOMIZED_CONFIGURATION",
-	      	  	'Lab.config.homeForSharing="' + getHomeForSharing() + '";\n' +
-	      	  	'Lab.config.homeEmbeddablePath="/embeddable.html' + window.location.hash + '";');
-	      	  var blob = new Blob([inlined], {type : 'text/html'});
-	      	  var blob_url = URL.createObjectURL(blob);
-	      	  $('#download_link_container').append('<a href="' + blob_url + '" download="' + interactive.title + '.html">Download HTML</a>');
-	      	  $('#standalone_html').val(inlined);
-            });
-        });
-  	  })();
+  // possible improvements:
 
-  	  // possible improvements:
+  // use blob urls with a dynamically created link with a download attribute so the
+  // user just needs to click the link to save the constructed template.html
 
-  	  // use blob urls with a dynamically created link with a download attribute so the
-  	  // user just needs to click the link to save the constructed template.html
+  // use a javascript zip library to constructure a full zip file client side that includes
+  // the interactive plus all of its resources. this would mean a multi mega byte blob
+  // though which might tax the browser memory
 
-  	  // use a javascript zip library to constructure a full zip file client side that includes
-  	  // the interactive plus all of its resources. this would mean a multi mega byte blob
-  	  // though which might tax the browser memory
+  // make a heroku app that can do the zip file combining for us:
+  // - you send the app a json struct with a base zip url
+  // - a set of additional "files" to add to base zip (with inline content)
 
-  	  // make a heroku app that can do the zip file combining for us:
-  	  // - you send the app a json struct with a base zip url
-  	  // - a set of additional "files" to add to base zip (with inline content)
-
-  	  // these approaches aren't going to handle the case where the model or interactive references
-  	  // resources like images, we'd need to search the interactive and model files for these and either
-  	  // inline them or if we had the zip file support we could add them to the zip
-  	</script>
-  </body>
+  // these approaches aren't going to handle the case where the model or interactive references
+  // resources like images, we'd need to search the interactive and model files for these and either
+  // inline them or if we had the zip file support we could add them to the zip
+</script>
+</body>
 </html>


### PR DESCRIPTION
Related to: https://github.com/concord-consortium/jsmol-models/pull/3

- Instructions with link 
- Preprocessing of Interacitve JSON: `interactiveDef = interactiveDef.replace('https://models-resources.concord.org/jsmol', 'jsmol-offline');`