### PR TITLE
Attempt to fix issue with `s3_website` while pushing commits.

### DIFF
--- a/script/s3-deploy.sh
+++ b/script/s3-deploy.sh
@@ -57,4 +57,9 @@ fi
 # It was downloaded either by ./script/popluate-standalone.sh or this script.
 rm lab.tar.gz
 
-bundle exec s3_website push --site _site --config-dir config
+
+# fixes issue with `s3_website` while pushing
+# tell the `s3_website` gem to only download the `.jar` file, then manually invoke it.
+# See: https://github.com/airbrake/airbrake-docs/commit/447ef0ca4fd2c638c1e66a3e3efc52d70ccf71fe
+bundle exec s3_website install
+java -cp $(bundle show s3_website)/*.jar s3.website.Push --site _site --config-dir config


### PR DESCRIPTION
Tell the `s3_website` gem to only download the `.jar` file, then manually invoke it.

Discussion:
https://github.com/laurilehmijoki/s3_website/issues/323

Sample workaround patch:
https://github.com/airbrake/airbrake-docs/commit/447ef0ca4fd2c638c1e66a3e3efc52d70ccf71fe