### PR TITLE
feat: Move models to S3 [QI-15]

### DIFF
--- a/src/interactives/inquiry-space/lactase.json
+++ b/src/interactives/inquiry-space/lactase.json
@@ -18,7 +18,7 @@
       "id": "iframe-model",
       "url": "models/lab-version/1/iframe-model/iframe-model.json",
       "modelOptions": {
-        "url": "//concord-consortium.github.io/lactase-enzyme-sim/embeddable.html",
+        "url": "//models-resources.concord.org/lactase-enzyme-sim/embeddable.html",
         "phFuncDef": [[0,0],[3.2,0.01],[3.8,0.02],[4.1,0.1],[5,0.65],[5.6,0.9],[6,1],[6.3,0.95],[6.6,0.85],[7.1,0.7],[7.3,0.45],[7.8,0.2],[8.3,0.15],[9.1,0.07],[10,0.01],[14,0]],
         "temperatureFuncDef": [[0,0.2],[10,0.5],[15,0.7],[20,0.9],[23,0.95],[30,0.98],[37,1],[40,0.95],[47,0.45],[50,0.35],[60,0.05],[65,0.02],[70,0.01],[80,0],[100,0]]
       },

--- a/src/interactives/planet-hunting/light-intensity.json
+++ b/src/interactives/planet-hunting/light-intensity.json
@@ -45,7 +45,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/light-intensity/",
+        "url": "//models-resources.concord.org/space-models/light-intensity/",
         "planet.diameter": 1
       }
     }

--- a/src/interactives/planet-hunting/planet-hunting-1.json
+++ b/src/interactives/planet-hunting/planet-hunting-1.json
@@ -15,7 +15,7 @@
   "about": [
   "Explore the gravitational effect an orbiting planet has on a star's motion.",
   "",
-  "Change the planet type to compare the effects of a rocky planet and a gaseous planet on star motion.",  
+  "Change the planet type to compare the effects of a rocky planet and a gaseous planet on star motion.",
   "",
   "Change the diameter of the planet to change the mass, and explore the effect of planet mass on star motion."
   ],
@@ -42,7 +42,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 1,
         "planet.rocky": true,
@@ -130,7 +130,7 @@
       "disabled": false,
       "tooltip": "",
       "helpIcon": false
-    },   
+    },
     {
       "id": "planet-mass",
       "type": "numericOutput",

--- a/src/interactives/planet-hunting/planet-hunting-10.json
+++ b/src/interactives/planet-hunting/planet-hunting-10.json
@@ -48,7 +48,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 1,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-11.json
+++ b/src/interactives/planet-hunting/planet-hunting-11.json
@@ -60,7 +60,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-12.json
+++ b/src/interactives/planet-hunting/planet-hunting-12.json
@@ -42,7 +42,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 1,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-2.json
+++ b/src/interactives/planet-hunting/planet-hunting-2.json
@@ -51,7 +51,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-3.json
+++ b/src/interactives/planet-hunting/planet-hunting-3.json
@@ -49,7 +49,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-4.json
+++ b/src/interactives/planet-hunting/planet-hunting-4.json
@@ -48,7 +48,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-6.json
+++ b/src/interactives/planet-hunting/planet-hunting-6.json
@@ -49,7 +49,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-7.json
+++ b/src/interactives/planet-hunting/planet-hunting-7.json
@@ -52,7 +52,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-8.json
+++ b/src/interactives/planet-hunting/planet-hunting-8.json
@@ -30,7 +30,7 @@
       "id": "iframe-model",
       "url": "models/lab-version/1/iframe-model/iframe-model.json",
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/"
+        "url": "//models-resources.concord.org/space-models/planet-hunting/"
       },
       "viewOptions": {
         "controlButtons": "play_reset",

--- a/src/interactives/planet-hunting/planet-hunting-9.json
+++ b/src/interactives/planet-hunting/planet-hunting-9.json
@@ -56,7 +56,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 10,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-master.json
+++ b/src/interactives/planet-hunting/planet-hunting-master.json
@@ -71,7 +71,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 1,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/planet-hunting-test.json
+++ b/src/interactives/planet-hunting/planet-hunting-test.json
@@ -19,7 +19,7 @@
       "id": "iframe-model",
       "url": "models/lab-version/1/iframe-model/iframe-model.json",
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/planet-hunting/",
+        "url": "//models-resources.concord.org/space-models/planet-hunting/",
         "timestep": 0.001,
         "planet.diameter": 1,
         "planet.rocky": true,

--- a/src/interactives/planet-hunting/wave-generator.json
+++ b/src/interactives/planet-hunting/wave-generator.json
@@ -46,7 +46,7 @@
         "controlButtons": "play_reset"
       },
       "modelOptions": {
-        "url": "//concord-consortium.github.io/space-models/wave-generator/",
+        "url": "//models-resources.concord.org/space-models/wave-generator/",
         "star.vx": 0
       }
     }


### PR DESCRIPTION
The following urls where moved from github.io to models-resources.concord.org:

- //concord-consortium.github.io/lactase-enzyme-sim/embeddable.html
- //concord-consortium.github.io/space-models/light-intensity/
- //concord-consortium.github.io/space-models/planet-hunting/
- //concord-consortium.github.io/space-models/wave-generator/

For posterity the urls were moved by downloading each page using wget and then using the aws cli to upload them to S3.  The dist and vendor folders in the top level space-models were also moved.